### PR TITLE
Update examples for CloudSim Plus 7.3.1

### DIFF
--- a/src/main/java/org/cloudsimplus/examples/VmGroupPlacementExample1.java
+++ b/src/main/java/org/cloudsimplus/examples/VmGroupPlacementExample1.java
@@ -123,7 +123,7 @@ public class VmGroupPlacementExample1 {
         final List<Cloudlet> finishedCloudlets = broker0.getCloudletFinishedList();
         finishedCloudlets.sort(Comparator.comparingLong(cl -> cl.getVm().getId()));
         new CloudletsTableBuilder(finishedCloudlets)
-            .addColumn(7, new TextTableColumn("      VmGroup"), cl -> cl.getVm().getGroup())
+            .addColumn(new TextTableColumn("      VmGroup"), cl -> cl.getVm().getGroup(), 7)
             .build();
     }
 

--- a/src/main/java/org/cloudsimplus/examples/brokers/DatacenterSelectionByTimeZoneExample.java
+++ b/src/main/java/org/cloudsimplus/examples/brokers/DatacenterSelectionByTimeZoneExample.java
@@ -130,8 +130,8 @@ public class DatacenterSelectionByTimeZoneExample {
         finishedCloudlets.sort(Comparator.comparingDouble(cl -> cl.getVm().getTimeZone()));
 
         new CloudletsTableBuilder(finishedCloudlets)
-                .addColumn(3, new TextTableColumn("   DC   ", "TimeZone"), this::getDatacenterTimeZone)
-                .addColumn(8, new TextTableColumn("VM Expected", " TimeZone "), this::getVmTimeZone)
+                .addColumn(new TextTableColumn("   DC   ", "TimeZone"), this::getDatacenterTimeZone, 3)
+                .addColumn(new TextTableColumn("VM Expected", " TimeZone "), this::getVmTimeZone, 8)
                 .build();
     }
 

--- a/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
+++ b/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
@@ -121,7 +121,6 @@ public class CostsExample1 {
         final DatacenterBroker broker = new DatacenterBrokerSimple(simulation);
         //Destroys idle VMs after some time (in seconds)
         broker.setVmDestructionDelay(0.2);
-        broker.setFailedVmsRetryDelay(-1);
         return broker;
     }
 

--- a/src/main/java/org/cloudsimplus/examples/dynamic/DynamicCloudletsArrival1.java
+++ b/src/main/java/org/cloudsimplus/examples/dynamic/DynamicCloudletsArrival1.java
@@ -132,9 +132,9 @@ public class DynamicCloudletsArrival1 {
         simulation.start();
         List<Cloudlet> cloudlets = broker.getCloudletFinishedList();
         new CloudletsTableBuilder(cloudlets)
-            .addColumn(7, new TextTableColumn("VM Arrived", "Time"), cl -> cl.getVm().getArrivedTime())
-            .addColumn(8, new TextTableColumn("VM Creation", "Time"), cl -> cl.getVm().getCreationTime())
-            .addColumn(9, new TextTableColumn("VM Wait", "Time"), cl -> cl.getVm().getWaitTime())
+            .addColumn(new TextTableColumn("VM Arrived", "Time"), cl -> cl.getVm().getArrivedTime(), 7)
+            .addColumn(new TextTableColumn("VM Creation", "Time"), cl -> cl.getVm().getCreationTime(), 8)
+            .addColumn(new TextTableColumn("VM Wait", "Time"), cl -> cl.getVm().getWaitTime(), 9)
             .build();
     }
 

--- a/src/main/java/org/cloudsimplus/examples/power/HostActivationExample.java
+++ b/src/main/java/org/cloudsimplus/examples/power/HostActivationExample.java
@@ -156,8 +156,8 @@ public class HostActivationExample {
         final List<Cloudlet> finishedCloudlets = broker0.getCloudletFinishedList();
         finishedCloudlets.sort(Comparator.comparingLong(Cloudlet::getLength).reversed());
         new CloudletsTableBuilder(finishedCloudlets)
-            .addColumn(4, new TextTableColumn("Start up time", "Seconds"), cl -> cl.getVm().getHost().getStartTime())
-            .addColumn(7, new TextTableColumn("Submission delay", "Seconds"), cl -> cl.getVm().getSubmissionDelay())
+            .addColumn(new TextTableColumn("Start up time", "Seconds"), cl -> cl.getVm().getHost().getStartTime(), 4)
+            .addColumn(new TextTableColumn("Submission delay", "Seconds"), cl -> cl.getVm().getSubmissionDelay(),  7)
             .build();
         printHostsUpTime();
     }
@@ -201,14 +201,14 @@ public class HostActivationExample {
 
         /*Indicates that idle VMs must be destroyed after some seconds.
         * This forces the Host to become idle.
-        * The delay should be larger then the simulation minTimeBetweenEvents to ensure VMs are gracefully shutdown. */
+        * The delay should be larger than the simulation minTimeBetweenEvents to ensure VMs are gracefully shutdown. */
         broker.setVmDestructionDelay(1.0);
 
         /*
          * Ensures that VMs which couldn't be created due to lack of suitable and active Hosts
          * will be retried to be placed after some time.
          */
-        broker.setFailedVmsRetryDelay(HOST_START_UP_DELAY+1);
+        broker.getVmCreation().setRetryDelay(HOST_START_UP_DELAY+1);
 
         return broker;
     }
@@ -222,7 +222,8 @@ public class HostActivationExample {
      */
     private void clockTickListener(final EventInfo info) {
         final double time = Math.floor(info.getTime());
-        if(time > lastClockTime && time > broker0.getFailedVmsRetryDelay() && time % SCHEDULING_INTERVAL == 0) {
+        final double retryDelay = broker0.getVmCreation().getRetryDelay();
+        if(time > lastClockTime && time > retryDelay && time % SCHEDULING_INTERVAL == 0) {
             if(vmList.size() < MAX_VMS) {
                 createAndSubmitVmsAndCloudlets(MIN_VMS);
             }

--- a/src/main/java/org/cloudsimplus/examples/resourceusage/HostsCpuUsageExample.java
+++ b/src/main/java/org/cloudsimplus/examples/resourceusage/HostsCpuUsageExample.java
@@ -113,8 +113,8 @@ public class HostsCpuUsageExample {
 
         List<Cloudlet> newList = broker.getCloudletFinishedList();
         new CloudletsTableBuilder(newList)
-            .addColumn(5, new TextTableColumn("Host  ", "MIPS  "), cloudlet -> cloudlet.getVm().getHost().getMips())
-            .addColumn(7, new TextTableColumn("VM MIPS"), cloudlet -> cloudlet.getVm().getMips())
+            .addColumn(new TextTableColumn("Host  ", "MIPS  "), cloudlet -> cloudlet.getVm().getHost().getMips(), 5)
+            .addColumn(new TextTableColumn("VM MIPS"), cloudlet -> cloudlet.getVm().getMips(), 7)
             .build();
 
         System.out.printf("%nHosts CPU utilization statistics%n");

--- a/src/main/java/org/cloudsimplus/examples/resourceusage/VirtualMemoryForRequestedRamHigherThanAvailableExample.java
+++ b/src/main/java/org/cloudsimplus/examples/resourceusage/VirtualMemoryForRequestedRamHigherThanAvailableExample.java
@@ -158,7 +158,7 @@ public class VirtualMemoryForRequestedRamHigherThanAvailableExample {
         final Comparator<Cloudlet> comparator = Comparator.comparingLong(cl -> cl.getVm().getId());
         finishedCloudlets.sort(comparator.thenComparing(Cloudlet::getId));
         new CloudletsTableBuilder(finishedCloudlets)
-            .addColumn(7, new TextTableColumn("VM RAM", "MB"), cl -> cl.getVm().getRam().getCapacity())
+            .addColumn(new TextTableColumn("VM RAM", "MB"), cl -> cl.getVm().getRam().getCapacity(), 7)
             .build();
 
         printOverSubscriptionDelay();

--- a/src/main/java/org/cloudsimplus/examples/resourceusage/VmsCpuUsageExample.java
+++ b/src/main/java/org/cloudsimplus/examples/resourceusage/VmsCpuUsageExample.java
@@ -110,7 +110,7 @@ public class VmsCpuUsageExample {
         simulation.start();
 
         new CloudletsTableBuilder(broker.getCloudletFinishedList())
-            .addColumn(7, new TextTableColumn("VM MIPS"), cl -> cl.getVm().getMips())
+            .addColumn(new TextTableColumn("VM MIPS"), cl -> cl.getVm().getMips(), 7)
             .build();
 
         printCpuUtilizationForAllVms();

--- a/src/main/java/org/cloudsimplus/examples/schedulers/LinuxCompletelyFairSchedulerExample.java
+++ b/src/main/java/org/cloudsimplus/examples/schedulers/LinuxCompletelyFairSchedulerExample.java
@@ -110,7 +110,7 @@ public class LinuxCompletelyFairSchedulerExample {
 
         List<Cloudlet> finishedCloudlets = broker0.getCloudletFinishedList();
         new CloudletsTableBuilder(finishedCloudlets)
-            .addColumn(2, new TextTableColumn("Priority"), Cloudlet::getPriority)
+            .addColumn(new TextTableColumn("Priority"), Cloudlet::getPriority, 2)
             .build();
         System.out.println(getClass().getSimpleName() + " finished!");
     }

--- a/src/main/java/org/cloudsimplus/examples/schedulers/VmSchedulerTimeSharedExample.java
+++ b/src/main/java/org/cloudsimplus/examples/schedulers/VmSchedulerTimeSharedExample.java
@@ -130,10 +130,10 @@ public class VmSchedulerTimeSharedExample {
         simulation.start();
 
         new CloudletsTableBuilder(broker0.getCloudletFinishedList())
-            .addColumn(5,  new TextTableColumn("Host MIPS", "total"), c -> c.getVm().getHost().getTotalMipsCapacity())
-            .addColumn(8,  new TextTableColumn("VM MIPS", "total"), c -> c.getVm().getTotalMipsCapacity())
-            .addColumn(9,  new TextTableColumn("  VM MIPS", "requested"), this::getVmRequestedMips)
-            .addColumn(10, new TextTableColumn("  VM MIPS", "allocated"), this::getVmAllocatedMips)
+            .addColumn(new TextTableColumn("Host MIPS", "total"), c -> c.getVm().getHost().getTotalMipsCapacity(), 5)
+            .addColumn(new TextTableColumn("VM MIPS", "total"), c -> c.getVm().getTotalMipsCapacity(), 8)
+            .addColumn(new TextTableColumn("  VM MIPS", "requested"), this::getVmRequestedMips, 9)
+            .addColumn(new TextTableColumn("  VM MIPS", "allocated"), this::getVmAllocatedMips, 10)
             .build();
 
         System.out.printf("%n-------------------------------------- Hosts CPU usage History --------------------------------------%n");

--- a/src/main/java/org/cloudsimplus/examples/traces/google/GoogleMachineEventsExample1.java
+++ b/src/main/java/org/cloudsimplus/examples/traces/google/GoogleMachineEventsExample1.java
@@ -118,7 +118,7 @@ public class GoogleMachineEventsExample1 {
 
         final List<Cloudlet> finishedCloudlets = broker0.getCloudletFinishedList();
         new CloudletsTableBuilder(finishedCloudlets)
-                .addColumn(5, new TextTableColumn("Host Startup", "Time"), this::getHostStartupTime)
+                .addColumn(new TextTableColumn("Host Startup", "Time"), this::getHostStartupTime, 5)
                 .build();
     }
 

--- a/src/main/java/org/cloudsimplus/examples/traces/google/GoogleTaskEventsExample1.java
+++ b/src/main/java/org/cloudsimplus/examples/traces/google/GoogleTaskEventsExample1.java
@@ -295,10 +295,10 @@ public class GoogleTaskEventsExample1 {
         final var cloudletList = broker.getCloudletFinishedList();
         cloudletList.sort(Comparator.comparingLong(Cloudlet::getId));
         new CloudletsTableBuilder(cloudletList)
-            .addColumn(0, new TextTableColumn("Job", "ID"), Cloudlet::getJobId)
-            .addColumn(7, new TextTableColumn("VM Size", "MB"), this::getVmSize)
-            .addColumn(8, new TextTableColumn("Cloudlet Size", "MB"), this::getCloudletSizeInMB)
-            .addColumn(10, new TextTableColumn("Waiting Time", "Seconds").setFormat("%.0f"), Cloudlet::getWaitingTime)
+            .addColumn(new TextTableColumn("Job", "ID"), Cloudlet::getJobId, 0)
+            .addColumn(new TextTableColumn("VM Size", "MB"), this::getVmSize, 7)
+            .addColumn(new TextTableColumn("Cloudlet Size", "MB"), this::getCloudletSizeInMB, 8)
+            .addColumn(new TextTableColumn("Waiting Time", "Seconds").setFormat("%.0f"), Cloudlet::getWaitingTime, 10)
             .setTitle("Simulation results for Broker " + broker.getId() + " representing the username " + username)
             .build();
     }


### PR DESCRIPTION
Removed `broker.setFailedVmsRetryDelay(-1);` that disables retry requests by default,
after fixing https://github.com/cloudsimplus/cloudsimplus/issues/349
and https://github.com/cloudsimplus/cloudsimplus/issues/404